### PR TITLE
babel.config.jsのコードの変更

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -54,7 +54,7 @@ module.exports = function(api) {
         }
       ],
       [
-        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-transform-private-methods',
         {
           loose: true
         }


### PR DESCRIPTION
・herokuへデプロイ時にコンパイルエラーが発生したため、
　記事を参考にコードを変更。