### PR TITLE
production.rbにコードを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  ENV['NODE_OPTIONS'] = '--openssl-legacy-provider'
 end


### PR DESCRIPTION
・herokuへのデプロイ時にエラーが発生。
　原因はNode.jsとOpenSSLの互換性の可能性あり。
・herokuの設定変更とproduction.rbにコードを追加。