### PR TITLE
seed.rakeファイルのコードの変更

### DIFF
--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,4 +1,4 @@
-Rails.root.glob('db', 'seeds', '*.rb').each do |file|
+Rails.root.glob('db/seeds/*.rb').each do |file|
   desc "Load the seed data from db/seeds/#{File.basename(file)}."
   task "db:seed:#{File.basename(file).gsub(/\..+$/, '')}" => :environment do
     load(file)


### PR DESCRIPTION
・herokuへseedの分割ファイルを追加できず。
・rakeファイルの記述を変えてみる。