### PR TITLE
投稿削除機能の作成　request_specへテストコードを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,3 +74,6 @@ Style/ClassAndModuleChildren:
 RSpec/VerifiedDoubleReference:
   Exclude:
     - 'spec/**/*_spec.rb'
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -151,6 +151,11 @@
   overflow:auto;
 }
 
+.current-user-review{
+  height: 300px;
+  overflow: auto;
+}
+
 @media screen and (max-width: 1024px){
   .user-warapper{
     margin: 150px 0px 10px 0px;

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -35,7 +35,7 @@ class FavoritesController < ApplicationController
 
     return unless @favorite.destroy
 
-    flash[:success] = I18n.t('flash.destroy.success')
+    flash[:success] = I18n.t('flash.destroy.favorite.success')
     redirect_back fallback_location: root_path
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,6 +20,13 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = current_user.posts.find(params[:id])
+    @post.destroy
+    flash[:success] = I18n.t('flash.destroy.post.success')
+    redirect_to user_path(current_user)
+  end
+
   private
 
   def google_places_client

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,8 +4,10 @@ class UsersController < ApplicationController
   def show
     if @user
       @favorites = @user.favorites.includes(:facility)
+      @user_reviews = @user.posts
     elsif current_user
       @favorites = current_user.favorites.includes(:facility)
+      @user_reviews = current_user.posts
     end
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,6 +21,27 @@
                 <button class="button prof-edit-btn"><%= link_to '編集する', edit_user_path(@user), class: "link edit-prof" %></button>
               <% end %>
             </span>
+            <div class="review-contents current-user-review">
+              <ul>
+                <% if @user_reviews.present? %>
+                  <% @user_reviews.each do |user_review| %>
+                    <li class="post-item">
+                      <div class="post-content">
+                        <div class="post-place-name">
+                          <%= link_to user_review.name, facilities_index_path(place_name: user_review.name), class: "post-place-name" %>
+                        </div>
+                        <h3 class="post-title"><%= user_review.title %></h3>
+                        <p class="post-review"><%= user_review.review %></p>
+                        <div class="post-time"><%= time_ago_in_words(user_review.created_at) %>前</div>
+                      </div>
+                      <% if current_user && current_user == user_review.user %>
+                        <%= button_to '削除', post_path(user_review.id), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'button destroy-btn' %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                <% end %>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,10 +3,12 @@ ja:
     create:
       success: '施設をお気に入りに登録しました'
     destroy:
-      success: 'お気に入りから削除しました'
+      favorite:
+        success: 'お気に入りから削除しました'
+      post:
+        success: '投稿を削除しました'
     review:
       success: 'レビューを投稿しました'
-      error: 'レビューの投稿ができませんでした'
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ Rails.application.routes.draw do
   end
 
   resources :users, only: [:show, :edit, :update]
-  resources :posts, only: [:new, :create]
+  resources :posts, only: [:new, :create, :destroy]
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
   let(:user) { create(:user) }
-  let(:new_post) { create(:post) }
   let(:place_name) { 'サウナ&ホテル かるまる池袋店' }
   let(:mock_client) { instance_double(GooglePlaces::Client) }
   let(:mock_place) { Struct.new(:name).new(place_name) }
@@ -51,22 +50,23 @@ RSpec.describe 'Posts', type: :request do
     end
   end
 
-  describe "DELETE #destroy" do
+  describe '#destroy' do
+    let(:new_post) { create(:post) }
     let!(:post_to_delete) { create(:post, user: user) }
 
     before do
       sign_in user
     end
 
-    it "deletes the post and redirects to the user's profile page" do
+    it '自身の投稿が削除でき、ユーザーページにリダイレクトできること' do
       expect do
         delete post_path(post_to_delete)
       end.to change(Post, :count).by(-1)
 
       expect(response).to redirect_to(user_path(user))
 
-      expect(Post.exists?(post_to_delete.id)).to be_falsey
-      expect(Post.exists?(new_post.id)).to be_truthy
+      expect(Post.where(id: post_to_delete.id)).not_to exist
+      expect(Post.where(id: new_post.id)).to exist
     end
   end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -50,4 +50,23 @@ RSpec.describe 'Posts', type: :request do
       expect(response).to render_template(:new)
     end
   end
+
+  describe "DELETE #destroy" do
+    let!(:post_to_delete) { create(:post, user: user) }
+
+    before do
+      sign_in user
+    end
+
+    it "deletes the post and redirects to the user's profile page" do
+      expect do
+        delete post_path(post_to_delete)
+      end.to change(Post, :count).by(-1)
+
+      expect(response).to redirect_to(user_path(user))
+
+      expect(Post.exists?(post_to_delete.id)).to be_falsey
+      expect(Post.exists?(new_post.id)).to be_truthy
+    end
+  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe 'Users', type: :request do
   let(:updated_user) { { user: { name: 'New Name', my_rule: 'a' * 100 } } }
   let(:facility) { create(:facility) }
   let!(:favorite) { create(:favorite, user: user, facility: facility) }
+  let!(:user_post) { create(:post, user: user) }
+  let!(:other_post) { create(:post, user: other_user) }
 
   describe '#show' do
     context '閲覧者がプロフィールの所有者の場合' do
@@ -44,6 +46,17 @@ RSpec.describe 'Users', type: :request do
 
       it '削除ボタンが表示されること' do
         expect(response.body).to include('削除する')
+      end
+
+      it "投稿内容が表示されること" do
+        expect(response.body).to include user_post.name
+        expect(response.body).to include user_post.title
+        expect(response.body).to include user_post.review
+      end
+
+      it "自身の投稿のみが表示されること" do
+        expect(assigns(:user_reviews)).to include(user_post)
+        expect(assigns(:user_reviews)).not_to include(other_post)
       end
     end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Users', type: :request do
   let(:user) { create(:user) }
   let(:other_user) { create(:user) }
-  let(:updated_user) { { user: { name: 'New Name', my_rule: 'a' * 100 } } }
   let(:facility) { create(:facility) }
   let!(:favorite) { create(:favorite, user: user, facility: facility) }
   let!(:user_post) { create(:post, user: user) }
@@ -48,15 +47,15 @@ RSpec.describe 'Users', type: :request do
         expect(response.body).to include('削除する')
       end
 
-      it "投稿内容が表示されること" do
+      it '自身の投稿のみが表示されること' do
+        expect(assigns(:user_reviews)).to include(user_post)
+        expect(assigns(:user_reviews)).not_to include(other_post)
+      end
+
+      it '投稿内容が表示されること' do
         expect(response.body).to include user_post.name
         expect(response.body).to include user_post.title
         expect(response.body).to include user_post.review
-      end
-
-      it "自身の投稿のみが表示されること" do
-        expect(assigns(:user_reviews)).to include(user_post)
-        expect(assigns(:user_reviews)).not_to include(other_post)
       end
     end
 
@@ -125,6 +124,8 @@ RSpec.describe 'Users', type: :request do
   end
 
   describe '#update' do
+    let(:updated_user) { { user: { name: 'New Name', my_rule: 'a' * 100 } } }
+
     context 'ユーザーが認証されている場合' do
       before do
         sign_in user

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe 'Posts', :js, type: :system do
 
   before do
     sign_in user
-    # allow_any_instance_of(GooglePlaces::Client).to receive(:spot).and_return(
-    #   Struct.new(name: post.name)
-    # )
     mock_place = Struct.new(:name).new(post.name)
     allow(mock_client).to receive(:spot).and_return(mock_place)
     allow(GooglePlaces::Client).to receive(:new).and_return(mock_client)

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Users', type: :system do
   let(:guest_user) { create(:user, name: 'ゲスト') }
   let(:facility) { create(:facility) }
   let!(:favorite) { create(:favorite, user: user, facility: facility) }
+  let!(:user_review) { create(:post, user: user) }
 
   describe '詳細ページのテスト' do
     context 'ログインしており、プロフィールの所有者である場合' do
@@ -75,6 +76,22 @@ RSpec.describe 'Users', type: :system do
           visit current_path
           expect(page).to have_no_content(favorite.facility.name)
         end
+      end
+
+      it '自身の投稿が表示され、削除ボタンを押下すると削除されること' do
+        expect(page).to have_content(user_review.name)
+        expect(page).to have_content(user_review.title)
+        expect(page).to have_content(user_review.review)
+        expect(page).to have_css('.post-time')
+
+        within '.post-item' do
+          click_on '削除'
+        end
+    
+        expect(page).not_to have_content(user_review.name)
+        expect(page).not_to have_content(user_review.title)
+        expect(page).not_to have_content(user_review.review)
+        expect(page).not_to have_css('.post-time')
       end
     end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -87,11 +87,11 @@ RSpec.describe 'Users', type: :system do
         within '.post-item' do
           click_on '削除'
         end
-    
-        expect(page).not_to have_content(user_review.name)
-        expect(page).not_to have_content(user_review.title)
-        expect(page).not_to have_content(user_review.review)
-        expect(page).not_to have_css('.post-time')
+
+        expect(page).to have_no_content(user_review.name)
+        expect(page).to have_no_content(user_review.title)
+        expect(page).to have_no_content(user_review.review)
+        expect(page).to have_no_css('.post-time')
       end
     end
 


### PR DESCRIPTION
・投稿を削除する機能を実装。
・ユーザー管理画面で自身が投稿したレビューを閲覧できるように実装。
・削除はユーザー管理画面で行うこととする。
・request_specにて削除と値が取得できていることのテストの追加。